### PR TITLE
Remove comprehensions from objective

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Parse files for [General Algebraic Modeling System](https://www.gams.com/) and return
 Julia expressions.
 As a matter of practicality, the only current purpose of this package is to parse
-the [problem files from Rios & Sahinidis](http://archimedes.cheme.cmu.edu/?q=dfocomp).
+the [problem files from Rios & Sahinidis](https://sahinidis.coe.gatech.edu/dfo).
 Please reach out if you'd like to help extend this package. 
 
 ## Demo

--- a/src/GAMSFiles.jl
+++ b/src/GAMSFiles.jl
@@ -570,7 +570,7 @@ function replace_reductions!(ex::Expr, sets)
                 push!(index_exprs, :($v = $rng))
             end
         end
-        return Expr(:call, gamsf2jf[ex.args[1]], Expr(:comprehension, Expr(:generator, val, index_exprs...)))
+        return Expr(:call, gamsf2jf[ex.args[1]], Expr(:generator, val, index_exprs...))
     end
     return ex
 end


### PR DESCRIPTION
Julia now supports `sum(r[i]^2 for i = 1:5)`, so the comprehension wrapper is unnecessary. Moreover, some autodiff packages like Enzyme don't like the comprehension.

Also updates the README link to reflect the current URL for the Rios & Sahinidis test problems.